### PR TITLE
Fixed size of Host List so items in it can be seen.

### DIFF
--- a/lib/SelfControl/UI.pm
+++ b/lib/SelfControl/UI.pm
@@ -275,6 +275,9 @@ sub build_ui {
   $list->set_data_array($self->{config}->{hosts});
   $list->get_selection->set_mode('multiple');
 
+  # we need the following line otherwise the list is too small
+  $list->set_size_request(350,500);
+
   my @columns = $list->get_columns;
   my $cnum = scalar(@columns);
   my $c;


### PR DESCRIPTION
I increased the size of the hosts list to 350x500 as before (at least in Ubuntu 11.10 and 12.04) it was impossible to see the content of it.

Ideally it should be resizeable, this is just a workaround for the moment.
